### PR TITLE
Add Placebo layout

### DIFF
--- a/config/layouts/placebo.yml
+++ b/config/layouts/placebo.yml
@@ -1,0 +1,6 @@
+name: placebo
+link: https://cyanophage.github.io/playground.html?layout=xlcmbjfou%3B-rnstgyheia'qzwdvkp%2C.%2F%5C
+thumb: false
+year: 2026
+website: https://t.me/klavaorgwork/931295
+family: ""


### PR DESCRIPTION
## Summary

Adds the Placebo layout requested in #172 by its author (@mailabuz).

- 30-key layout, no thumb alpha
- Year: 2026
- Website: https://t.me/klavaorgwork/931295 (author's announcement on Telegram)

## Issues closed

Closes #172

## Test plan

- [ ] `update_data.yml` workflow scrapes stats for the new layout into `site/data.json`
- [ ] Placebo renders on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)