### PR TITLE
Add Northwest layout

### DIFF
--- a/config/layouts/northwest.yml
+++ b/config/layouts/northwest.yml
@@ -1,0 +1,6 @@
+name: northwest
+link: https://cyanophage.github.io/playground.html?layout=blmpw%5Cuoy-%27nrtdf%5Eeaih%2Cxzvcgj%2F%3B.kqs&thumb=l
+thumb: true
+year: 2026
+website: https://rbscholtus.github.io/keycraft/layouts/northwest.html
+family: ""


### PR DESCRIPTION
## Summary

Adds the Northwest layout by Barend Scholtus (@rbscholtus), currently the top-ranked layout on his [Keycraft analyzer](https://rbscholtus.github.io/keycraft/index.html).

- Source: https://rbscholtus.github.io/keycraft/layouts/northwest.html
- Source layout file: [northwest.klf](https://github.com/rbscholtus/keycraft/blob/main/data/layouts/northwest.klf)
- Year: 2026 (added to keycraft 2026-01-17)
- Thumb: \`s\` on left thumb

## Encoding notes

Northwest is a 36-key layout with a thumb cluster (1 outer-pinky on both sides). Cyanophage's 33+thumb URL format can't represent everything precisely; the encoding compromises are:

- **\`j\` (outer-right-pinky bottom)**: cyanophage has no URL slot for that position (QWERTY enter). Placed at position 27 instead — the right-inner-index bottom slot, which is empty in actual northwest. \`j\` is ~0.15% English frequency so the analysis impact is minimal.
- **\`\`\` (outer-right-pinky top)**: not in cyanophage's char set, substituted with \`'\` as visual placeholder.
- **\`=\` (right-inner-index home)**: emitted via \`^\` which cyanophage auto-converts to \`=\` at non-thumb positions.
- **Right thumbs (\`_\`, \`'\`)**: cyanophage models a single thumb; right thumbs aren't alphas so omitted.

All 26 alphas placed at the correct columns/rows except \`j\` as noted above.

## Test plan

- [ ] \`update_data.yml\` workflow scrapes stats for the new layout into \`site/data.json\`
- [ ] Northwest renders on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)