### PR TITLE
Add Strata layout

### DIFF
--- a/config/layouts/strata.yml
+++ b/config/layouts/strata.yml
@@ -1,0 +1,6 @@
+name: strata
+link: https://cyanophage.github.io/playground.html?layout=bldwqjfou%27-nrtsgyhaei%3Bzxmcvkp%2F%2C.%5C%5E
+thumb: false
+year: 2026
+website: https://github.com/ncpir/strata
+family: ""


### PR DESCRIPTION
## Summary

Adds the Strata layout by @ncpir from https://github.com/ncpir/strata.

- Year: 2026 (repo created 2026-04-15)
- Standard 30-key layout with thumb-cluster modifiers (Nav, Space, Sym, oneshot Shift) — no alphas on thumbs

## Layout (from canonical [keyd config](https://github.com/ncpir/strata/blob/main/keyd/default.conf))

\`\`\`
Top:    b l d w q | j f o u '
Home:   n r t s g | y h a e i
Bottom: z x m c v | k p _ , .
\`\`\`

Verified against the base.svg keypos coordinates in the repo.

## Encoding note

The \`_\` (underscore) at right-middle bottom isn't in cyanophage's character set; substituted with \`/\` as a non-alpha placeholder. Doesn't affect alpha stats.

## Test plan

- [ ] \`update_data.yml\` workflow scrapes stats for the new layout into \`site/data.json\`
- [ ] Strata renders on the deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)