### PR TITLE
Split stats settings out of the filters panel

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -78,9 +78,13 @@
                     >
                 </div>
                 <div class="search-bar-actions">
-                    <button class="icon-btn filter-toggle-btn" id="filterToggleBtn" title="Filters & Settings" aria-label="Toggle filters">
-                        <i class="fa-solid fa-sliders"></i>
+                    <button class="icon-btn filter-toggle-btn" id="filterToggleBtn" title="Filter layouts" aria-label="Toggle filters">
+                        <i class="fa-solid fa-filter"></i>
                         <span class="filter-badge" id="filterBadge"></span>
+                    </button>
+                    <button class="icon-btn scoring-toggle-btn" id="scoringToggleBtn" title="Score weights" aria-label="Toggle score weights">
+                        <i class="fa-solid fa-sliders"></i>
+                        <span class="filter-badge" id="scoringBadge"></span>
                     </button>
                     <button class="icon-btn share-btn" id="shareBtn" title="Copy shareable link" aria-label="Share">
                         <i class="fa-solid fa-share-nodes"></i>
@@ -88,48 +92,53 @@
                 </div>
             </div>
 
-            <!-- Filter dropdown panel -->
+            <!-- Stats settings: always visible, because they change every number in the table -->
+            <div class="stats-settings">
+                <span class="stats-settings-text">Stats for</span>
+                <div class="stats-setting">
+                    <i class="fa-solid fa-earth-americas"></i>
+                    <select id="languageSelect" class="setting-select" aria-label="Language">
+                        <option value="english">English</option>
+                    </select>
+                </div>
+                <span class="stats-settings-text">typed on a</span>
+                <div class="stats-setting">
+                    <i class="fa-solid fa-keyboard"></i>
+                    <select id="modeSelect" class="setting-select" aria-label="Keyboard type">
+                        <option value="ergo">Ergo (column-staggered)</option>
+                        <option value="ansi">ANSI (row-staggered)</option>
+                        <option value="iso">ISO (row-staggered)</option>
+                        <option value="anglemod">Angle Mod (ISO)</option>
+                    </select>
+                </div>
+                <span class="stats-settings-text">keyboard</span>
+                <span class="tooltip tooltip-wide stats-settings-help" data-tooltip="The keyboard shape decides which finger presses which key, so it changes every metric below. Angle Mod is an ISO board where the left bottom row shifts one key to the right, moving ZXCV onto more natural fingers.">
+                    <i class="fa-regular fa-circle-question"></i>
+                </span>
+            </div>
+
+            <!-- Filter dropdown panel: narrows down which layouts are listed -->
             <div class="filter-panel" id="filterPanel">
                 <div class="filter-panel-section">
-                    <div class="filter-panel-label">Thumbs</div>
+                    <div class="filter-panel-label">Thumb keys</div>
                     <div class="segment-control" id="thumbSegment">
                         <button class="segment-btn active" data-value="all">All</button>
-                        <button class="segment-btn" data-value="true">With Thumbs</button>
-                        <button class="segment-btn" data-value="false">No Thumbs</button>
-                    </div>
-                    <!-- Hidden radios for compatibility with existing JS -->
-                    <input type="radio" name="thumbFilter" value="all" checked style="display:none">
-                    <input type="radio" name="thumbFilter" value="true" style="display:none">
-                    <input type="radio" name="thumbFilter" value="false" style="display:none">
-                </div>
-
-                <div class="filter-panel-row">
-                    <div class="filter-panel-field">
-                        <label for="languageSelect">Language</label>
-                        <select id="languageSelect" class="filter-select">
-                            <option value="english">English</option>
-                        </select>
-                    </div>
-                    <div class="filter-panel-field">
-                        <label for="modeSelect">Keyboard</label>
-                        <select id="modeSelect" class="filter-select">
-                            <option value="ergo">Ergo</option>
-                            <option value="ansi">ANSI</option>
-                            <option value="iso">ISO</option>
-                            <option value="anglemod">Angle Mod</option>
-                        </select>
-                    </div>
-                    <div class="filter-panel-field">
-                        <label for="familySelect">Families</label>
-                        <select id="familySelect" class="filter-select">
-                            <option value="collapsed">Collapsed</option>
-                            <option value="show-all">Show All</option>
-                        </select>
+                        <button class="segment-btn" data-value="true">With thumbs</button>
+                        <button class="segment-btn" data-value="false">No thumbs</button>
                     </div>
                 </div>
 
-                <div class="filter-panel-divider"></div>
+                <div class="filter-panel-section">
+                    <div class="filter-panel-label">Layout families</div>
+                    <div class="segment-control" id="familySegment">
+                        <button class="segment-btn active" data-value="collapsed">Grouped</button>
+                        <button class="segment-btn" data-value="show-all">Show all</button>
+                    </div>
+                </div>
+            </div>
 
+            <!-- Scoring dropdown panel: changes how the Score column is calculated -->
+            <div class="filter-panel" id="scoringPanel">
                 <div class="filter-panel-section">
                     <div class="filter-panel-label">Score Preset</div>
                     <div class="preset-buttons">

--- a/site/script.js
+++ b/site/script.js
@@ -55,7 +55,15 @@ function updateUrlParams() {
     if (searchInput && searchInput.value.trim()) {
         params.set('search', searchInput.value.trim());
     }
-    
+
+    // Add row filters (only if not default)
+    if (currentThumbFilter !== 'all') {
+        params.set('thumbs', currentThumbFilter);
+    }
+    if (currentFamilyMode !== 'collapsed') {
+        params.set('families', currentFamilyMode);
+    }
+
     // Add weights - check if it matches a preset
     let activePreset = null;
     for (const [presetName, presetWeights] of Object.entries(weightPresets)) {
@@ -119,7 +127,18 @@ function loadFromUrlParams() {
             searchInput.value = search;
         }
     }
-    
+
+    // Load row filters
+    const thumbs = params.get('thumbs');
+    if (thumbs === 'all' || thumbs === 'true' || thumbs === 'false') {
+        currentThumbFilter = thumbs;
+    }
+
+    const families = params.get('families');
+    if (families === 'collapsed' || families === 'show-all') {
+        currentFamilyMode = families;
+    }
+
     // Load weights - either from preset or custom weights
     const preset = params.get('preset');
     const weights = params.get('weights');
@@ -159,6 +178,8 @@ function loadFromUrlParams() {
         lang,
         mode,
         search,
+        thumbs,
+        families,
         preset,
         weights,
         highlight,
@@ -249,7 +270,7 @@ function setupWeightControls() {
                 saveScoreWeights();
                 updateActivePreset();
                 updateUrlParams();
-                updateFilterBadge();
+                updateBadges();
                 recalculateAndRender();
             });
             
@@ -262,7 +283,7 @@ function setupWeightControls() {
                 saveScoreWeights();
                 updateActivePreset();
                 updateUrlParams();
-                updateFilterBadge();
+                updateBadges();
                 recalculateAndRender();
             });
         }
@@ -272,15 +293,13 @@ function setupWeightControls() {
     document.querySelectorAll('.preset-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             const preset = btn.dataset.preset;
-            const customPanel = document.getElementById('customWeightsPanel');
-            
             if (preset === 'custom') {
                 // Custom button: just mark it as active
                 // Mark Custom as active
                 document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
                 saveSelectedPreset('custom');
-                updateFilterBadge();
+                updateBadges();
             } else if (weightPresets[preset]) {
                 // Regular preset: apply the preset weights
                 scoreWeights = { ...weightPresets[preset] };
@@ -288,7 +307,7 @@ function setupWeightControls() {
                 updateWeightUI();
                 updateActivePreset();
                 updateUrlParams();
-                updateFilterBadge();
+                updateBadges();
                 recalculateAndRender();
             }
         });
@@ -447,7 +466,7 @@ function setupLanguageFilter() {
         
         // Update URL params
         updateUrlParams();
-        updateFilterBadge();
+        updateBadges();
     });
 }
 
@@ -473,29 +492,55 @@ function setupModeFilter() {
         
         // Update URL params
         updateUrlParams();
-        updateFilterBadge();
+        updateBadges();
     });
 }
 
-// Family filter functionality
-function setupFamilyFilter() {
-    const familySelect = document.getElementById('familySelect');
-    if (!familySelect) return;
-    
-    // Restore saved preference
-    const saved = localStorage.getItem('familyMode') || 'collapsed';
-    currentFamilyMode = saved;
-    familySelect.value = saved;
-    
-    familySelect.addEventListener('change', (e) => {
-        currentFamilyMode = e.target.value;
-        localStorage.setItem('familyMode', currentFamilyMode);
-        expandedFamilies.clear(); // Reset expanded state when switching modes
-        updateFilterBadge();
-        const filtered = getFilteredData();
-        const sorted = sortData(filtered);
-        renderTable(sorted);
+// Mark the button matching `value` as the active one in a segment control
+function updateSegmentControl(segmentId, value) {
+    const segment = document.getElementById(segmentId);
+    if (!segment) return;
+    segment.querySelectorAll('.segment-btn').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.value === value);
     });
+}
+
+// Row filters (thumbs + families): restore saved state and wire up the segment controls
+function setupRowFilters(urlState) {
+    if (!urlState.thumbs) {
+        currentThumbFilter = localStorage.getItem('thumbFilter') || 'all';
+    }
+    if (!urlState.families) {
+        currentFamilyMode = localStorage.getItem('familyMode') || 'collapsed';
+    }
+    updateSegmentControl('thumbSegment', currentThumbFilter);
+    updateSegmentControl('familySegment', currentFamilyMode);
+
+    document.querySelectorAll('#thumbSegment .segment-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            currentThumbFilter = btn.dataset.value;
+            localStorage.setItem('thumbFilter', currentThumbFilter);
+            updateSegmentControl('thumbSegment', currentThumbFilter);
+            updateSearchPlaceholder();
+            applyRowFilterChange();
+        });
+    });
+
+    document.querySelectorAll('#familySegment .segment-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            currentFamilyMode = btn.dataset.value;
+            localStorage.setItem('familyMode', currentFamilyMode);
+            updateSegmentControl('familySegment', currentFamilyMode);
+            expandedFamilies.clear(); // Reset expanded state when switching modes
+            applyRowFilterChange();
+        });
+    });
+}
+
+function applyRowFilterChange() {
+    updateBadges();
+    updateUrlParams();
+    renderTable(sortData(getFilteredData()));
 }
 
 // Update the try-layout link to include current language
@@ -626,8 +671,10 @@ function groupByFamily(filteredLayouts) {
 
 // Update search placeholder with count
 function updateSearchPlaceholder() {
-    const count = layoutsData.length;
-    document.getElementById('searchInput').placeholder = 
+    const count = currentThumbFilter === 'all'
+        ? layoutsData.length
+        : layoutsData.filter(layout => layout.thumb.toString() === currentThumbFilter).length;
+    document.getElementById('searchInput').placeholder =
         `Search ${count} layout${count !== 1 ? 's' : ''}...`;
 }
 
@@ -676,8 +723,8 @@ async function loadData() {
         initModeSelect();
         setupModeFilter();
         
-        // Setup family filter
-        setupFamilyFilter();
+        // Setup row filters (thumbs + families)
+        setupRowFilters(urlState);
         
         // If URL had a mode param, override the default/saved mode
         if (urlState.mode) {
@@ -720,7 +767,7 @@ async function loadData() {
         
         // Initialize URL params (in case we loaded from localStorage)
         updateUrlParams();
-        updateFilterBadge();
+        updateBadges();
     } catch (error) {
         console.error('Error loading data:', error);
         document.getElementById('tableBody').innerHTML = 
@@ -1164,22 +1211,6 @@ document.querySelectorAll('th[data-column]').forEach(th => {
 // Load data on page load
 loadData();
 
-// Add click handler for the "customize weights" link
-document.querySelector('.score-link')?.addEventListener('click', (e) => {
-    e.preventDefault();
-    const fp = document.getElementById('filterPanel');
-    const ftb = document.getElementById('filterToggleBtn');
-    if (fp) {
-        fp.classList.add('open');
-        if (ftb) ftb.classList.add('active');
-        const customBtn = document.querySelector('.preset-btn[data-preset="custom"]');
-        if (customBtn) {
-            document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
-            customBtn.classList.add('active');
-        }
-    }
-});
-
 // Share button functionality
 const shareBtn = document.getElementById('shareBtn');
 
@@ -1206,49 +1237,37 @@ shareBtn?.addEventListener('click', async () => {
     }
 });
 
-// Filter panel toggle
-const filterToggleBtn = document.getElementById('filterToggleBtn');
-const filterPanel = document.getElementById('filterPanel');
+// Dropdown panels: filters (which layouts are listed) and scoring (how Score is calculated)
+const dropdownPanels = [
+    { button: document.getElementById('filterToggleBtn'), panel: document.getElementById('filterPanel') },
+    { button: document.getElementById('scoringToggleBtn'), panel: document.getElementById('scoringPanel') }
+].filter(({ button, panel }) => button && panel);
 
-if (filterToggleBtn && filterPanel) {
-    filterToggleBtn.addEventListener('click', (e) => {
+function closeDropdownPanels(except = null) {
+    dropdownPanels.forEach(({ button, panel }) => {
+        if (panel === except) return;
+        panel.classList.remove('open');
+        button.classList.remove('active');
+    });
+}
+
+dropdownPanels.forEach(({ button, panel }) => {
+    button.addEventListener('click', (e) => {
         e.stopPropagation();
-        const isOpen = filterPanel.classList.toggle('open');
-        filterToggleBtn.classList.toggle('active', isOpen);
+        closeDropdownPanels(panel);
+        const isOpen = panel.classList.toggle('open');
+        button.classList.toggle('active', isOpen);
     });
+});
 
-    // Close panel when clicking outside
-    document.addEventListener('click', (e) => {
-        if (!filterPanel.contains(e.target) && !filterToggleBtn.contains(e.target)) {
-            filterPanel.classList.remove('open');
-            filterToggleBtn.classList.remove('active');
-        }
-    });
-}
-
-// Segment control for thumb filter
-const thumbSegment = document.getElementById('thumbSegment');
-if (thumbSegment) {
-    thumbSegment.querySelectorAll('.segment-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-            // Update visual state
-            thumbSegment.querySelectorAll('.segment-btn').forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            
-            // Update hidden radio and state
-            const value = btn.dataset.value;
-            const radio = document.querySelector(`input[name="thumbFilter"][value="${value}"]`);
-            if (radio) radio.checked = true;
-            currentThumbFilter = value;
-            updateSearchPlaceholder();
-            updateFilterBadge();
-            
-            const filtered = getFilteredData();
-            const sorted = sortData(filtered);
-            renderTable(sorted);
-        });
-    });
-}
+// Close panels when clicking outside of them
+document.addEventListener('click', (e) => {
+    const clickedInside = dropdownPanels.some(({ button, panel }) =>
+        panel.contains(e.target) || button.contains(e.target));
+    if (!clickedInside) {
+        closeDropdownPanels();
+    }
+});
 
 // Learn more toggle
 const learnMoreToggle = document.getElementById('learnMoreToggle');
@@ -1261,19 +1280,12 @@ if (learnMoreToggle && learnMoreContent) {
     });
 }
 
-// Update filter badge to show when non-default filters are active
-function updateFilterBadge() {
-    const badge = document.getElementById('filterBadge');
-    if (!badge) return;
-    
-    const hasNonDefault = 
-        currentThumbFilter !== 'all' ||
-        (window.currentLanguage && window.currentLanguage !== 'english') ||
-        (window.currentMode && window.currentMode !== 'ergo') ||
-        currentFamilyMode !== 'collapsed' ||
-        !isDefaultWeights();
-    
-    badge.classList.toggle('visible', hasNonDefault);
+// Show a dot on each toggle button whose panel holds non-default settings.
+// Language and keyboard type are always visible in the stats settings bar, so they need no dot.
+function updateBadges() {
+    document.getElementById('filterBadge')?.classList.toggle('visible',
+        currentThumbFilter !== 'all' || currentFamilyMode !== 'collapsed');
+    document.getElementById('scoringBadge')?.classList.toggle('visible', !isDefaultWeights());
 }
 
 function isDefaultWeights() {

--- a/site/styles.css
+++ b/site/styles.css
@@ -462,6 +462,70 @@ body.dark-mode .icon-btn.active {
     color: #48bb78;
 }
 
+/* Stats settings bar (always visible - these change the numbers in the table) */
+.stats-settings {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.6rem;
+    font-size: 0.9rem;
+    color: var(--text-secondary, #718096);
+}
+
+.stats-setting {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.6rem;
+    border: 1.5px solid #e2e8f0;
+    border-radius: 8px;
+    background: var(--bg-secondary, white);
+    transition: border-color 0.2s ease;
+}
+
+.stats-setting:hover,
+.stats-setting:focus-within {
+    border-color: var(--accent-color, #667eea);
+}
+
+.stats-setting i {
+    color: var(--accent-color, #667eea);
+    font-size: 0.85rem;
+}
+
+.setting-select {
+    border: none;
+    background: transparent;
+    color: var(--text-primary, #1a202c);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    outline: none;
+    padding: 0;
+}
+
+.stats-settings-help {
+    color: var(--text-tertiary, #a0aec0);
+}
+
+body.dark-mode .stats-settings {
+    color: #a0aec0;
+}
+
+body.dark-mode .stats-setting {
+    background: #2d3748;
+    border-color: #4a5568;
+}
+
+body.dark-mode .setting-select {
+    color: #e2e8f0;
+}
+
+body.dark-mode .setting-select option {
+    background: #2d3748;
+}
+
 /* Filter panel (slide-open, pushes content down) */
 .filter-panel {
     overflow: hidden;
@@ -476,7 +540,10 @@ body.dark-mode .icon-btn.active {
 }
 
 .filter-panel.open {
-    max-height: 800px;
+    /* Tall enough for the weight sliders plus an expanded score explanation;
+       scrolls internally rather than clipping on short screens. */
+    max-height: 85vh;
+    overflow-y: auto;
     opacity: 1;
     padding: 1.25rem;
     margin-top: 0.5rem;
@@ -508,51 +575,6 @@ body.dark-mode .filter-panel.open {
     letter-spacing: 0.05em;
     color: var(--text-tertiary, #a0aec0);
     margin-bottom: 0.5rem;
-}
-
-.filter-panel-row {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
-}
-
-.filter-panel-field {
-    flex: 1;
-    min-width: 140px;
-}
-
-.filter-panel-field label {
-    display: block;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-tertiary, #a0aec0);
-    margin-bottom: 0.35rem;
-}
-
-.filter-select {
-    width: 100%;
-    padding: 0.5rem 0.75rem;
-    border: 1.5px solid #e2e8f0;
-    border-radius: 8px;
-    font-size: 0.9rem;
-    background: var(--bg-primary, #f7fafc);
-    color: var(--text-primary, #1a202c);
-    cursor: pointer;
-    transition: border-color 0.2s;
-}
-
-.filter-select:focus {
-    outline: none;
-    border-color: var(--accent-color, #667eea);
-}
-
-body.dark-mode .filter-select {
-    background: #1a202c;
-    border-color: #4a5568;
-    color: #e2e8f0;
 }
 
 .filter-panel-divider {
@@ -1100,6 +1122,19 @@ body.dark-mode tbody tr.last-pinned {
     z-index: 1000;
 }
 
+/* Wide tooltips for longer explanations (wraps instead of one long line) */
+.tooltip-wide {
+    border-bottom: none;
+}
+
+.tooltip-wide::after {
+    white-space: normal;
+    width: max-content;
+    max-width: min(360px, 80vw);
+    text-align: left;
+    line-height: 1.4;
+}
+
 /* Right-aligned tooltips for last columns */
 th:nth-last-child(-n+4) .tooltip::after {
     left: auto;
@@ -1607,13 +1642,14 @@ body.dark-mode .score-value {
         padding: 0.75rem;
     }
 
-    .filter-panel-row {
-        flex-direction: column;
-        gap: 0.75rem;
+    .stats-settings {
+        font-size: 0.85rem;
+        gap: 0.35rem;
     }
 
-    .filter-panel-field {
-        min-width: 100%;
+    .setting-select {
+        font-size: 0.85rem;
+        max-width: 100%;
     }
 
     .segment-control {


### PR DESCRIPTION
## Summary

Closes #192. In that issue a layout author reported wrong fingering for Grawerty; the data was right — they were looking at the default *ergo* view instead of *Angle Mod*. Their follow-up was "I don't find Angle Mod on your site", and you agreed the UI hid it.

The root cause is that one `sliders` dropdown held three different kinds of control:

- **settings** that change every number in the table (language, keyboard type)
- **filters** that change which rows are listed (thumb keys, families)
- **scoring** that changes how the Score column is computed (preset + weights)

So this splits them by kind:

**Always visible** — a settings bar under the search box reading *"Stats for `[English]` typed on a `[Ergo (column-staggered)]` keyboard"*. Both are plain selects, so the current context is readable at a glance instead of being two clicks deep. Keyboard options now say what they are (`Ergo (column-staggered)`, `ANSI (row-staggered)`, `ISO (row-staggered)`, `Angle Mod (ISO)`), and a `?` tooltip explains that keyboard shape decides which finger presses which key — the thing that confused the reporter.

**Funnel icon** — row filters only (thumb keys, families). Families moved from a `<select>` to a segment control so it matches the thumbs filter.

**Sliders icon** — score preset + weights + the score formula explainer.

Each dropdown has its own badge dot, and opening one closes the other. Language/keyboard no longer need a badge because they are always on screen.

### Fixes the split surfaced

- `thumbs` and `families` are now URL params, so the share button no longer silently drops them
- the thumb filter now persists across reloads (families already did)
- the search placeholder counts what the thumb filter leaves ("Search 43 layouts…"), which is what the existing call site clearly intended
- the score explanation no longer clips: the panel was capped at `max-height: 800px` with `overflow: hidden`, so expanding "How is the score calculated?" cut off the formulas. It is now `85vh` with internal scrolling
- removed the dead `.score-link` handler and the hidden `thumbFilter` radios (nothing read them)

## Test plan

Verified in Chromium (headless Playwright) against the local site:

- [x] Language and keyboard selects are visible without opening any panel; switching to Angle Mod changes the numbers (colemak family: SFB 0.91% → 1.08%, score 44.7% → 43.2%) and the URL
- [x] Opening filters closes scoring and vice versa; clicking outside closes both
- [x] Badges: funnel dot only for non-default thumbs/families, sliders dot only for non-default weights
- [x] Share URL round-trips in a fresh browser context with no localStorage: `?mode=anglemod&thumbs=true&families=show-all&preset=comfort` restores all four controls
- [x] Thumb filter survives a reload with no URL params; placeholder shows 43 with-thumb / 113 no-thumb / 156 total
- [x] Score explanation expands fully inside the scoring panel
- [x] Checked light + dark mode and a 420px mobile viewport (settings bar wraps to two lines)
- [x] Layout accordion still opens and language changes still recalculate the table
- [x] `npm test`, `node site/layout-scores.standalone-test.mjs`, `uv run pytest scripts/test_scrape_stats.py` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)